### PR TITLE
Fix ProductDao.getProductsByIngestionDate to return products by ingestion date

### DIFF
--- a/core/src/main/java/fr/gael/dhus/database/dao/ProductDao.java
+++ b/core/src/main/java/fr/gael/dhus/database/dao/ProductDao.java
@@ -294,8 +294,8 @@ public class ProductDao extends HibernateDao<Product, Long>
       SimpleDateFormat sdf = new SimpleDateFormat ("yyyy-MM-dd HH:mm:ss.SSS");
       String date = sdf.format (max_date);
       String query = "FROM " + entityClass.getName () + " " +
-            "WHERE created < '" + date + "' AND processed=true AND " +
-            "locked=false ORDER BY created ASC, updated ASC";
+            "WHERE ingestiondate < '" + date + "' AND processed=true AND " +
+            "locked=false ORDER BY ingestiondate ASC, updated ASC";
       return new PagedIterator<> (this, query);
    }
    


### PR DESCRIPTION
`ProductDao.getProductsByIngestionDate` is used by `EvictionStrategy` to determine the products to be evicted based on the ingestion date.

The underlying database query that this method used though was returning products according to the creation date which can greatly differ from the ingestion date, leading to a different-than-expected eviction strategy applied.

This pull requests fixes the query performed by the aforementioned method.